### PR TITLE
fix: VPS-4617 publish server to modelcontexprotocol registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hostinger-api-mcp",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hostinger-api-mcp",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hostinger-api-mcp",
-  "version": "0.1.18",
+  "version": "0.1.19",
+  "mcpName": "io.github.hostinger/api-mcp-server",
   "description": "MCP server for Hostinger API",
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -3422,7 +3422,7 @@ class MCPServer {
     this.server = new Server(
       {
         name: "hostinger-api-mcp",
-        version: "0.1.18",
+        version: "0.1.19",
       },
       {
         capabilities: {
@@ -3447,7 +3447,7 @@ class MCPServer {
       });
     }
     
-    headers['User-Agent'] = 'hostinger-mcp-server/0.1.18';
+    headers['User-Agent'] = 'hostinger-mcp-server/0.1.19';
     
     return headers;
   }

--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.hostinger/api-mcp-server",
+  "description": "MCP server for Hostinger API",
+  "repository": {
+    "url": "https://github.com/hostinger/api-mcp-server",
+    "source": "github"
+  },
+  "version": "0.1.19",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "hostinger-api-mcp",
+      "version": "0.1.19",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "API_TOKEN",
+          "description": "Hostinger API token",
+          "isRequired": true,
+          "isSecret": true,
+          "format": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/server.ts
+++ b/server.ts
@@ -3444,7 +3444,7 @@ class MCPServer {
     this.server = new Server(
       {
         name: "hostinger-api-mcp",
-        version: "0.1.18",
+        version: "0.1.19",
       },
       {
         capabilities: {
@@ -3469,7 +3469,7 @@ class MCPServer {
       });
     }
     
-    headers['User-Agent'] = 'hostinger-mcp-server/0.1.18';
+    headers['User-Agent'] = 'hostinger-mcp-server/0.1.19';
     
     return headers;
   }


### PR DESCRIPTION
## Related Issue
 https://hostingers.atlassian.net/browse/VPS-4617



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.19 across package configuration and server initialization
  * Added MCP server configuration descriptor with metadata and package information
  * Updated User-Agent headers to reflect new version

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->