### PR TITLE
fix: VPS-4617 using server name instead of repo name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hostinger-api-mcp",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hostinger-api-mcp",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hostinger-api-mcp",
-  "version": "0.1.19",
-  "mcpName": "io.github.hostinger/api-mcp-server",
+  "version": "0.1.20",
+  "mcpName": "io.github.hostinger/hostinger-api-mcp",
   "description": "MCP server for Hostinger API",
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -3422,7 +3422,7 @@ class MCPServer {
     this.server = new Server(
       {
         name: "hostinger-api-mcp",
-        version: "0.1.19",
+        version: "0.1.20",
       },
       {
         capabilities: {
@@ -3447,7 +3447,7 @@ class MCPServer {
       });
     }
     
-    headers['User-Agent'] = 'hostinger-mcp-server/0.1.19';
+    headers['User-Agent'] = 'hostinger-mcp-server/0.1.20';
     
     return headers;
   }

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
-  "name": "io.github.hostinger/api-mcp-server",
+  "name": "io.github.hostinger/hostinger-api-mcp",
   "description": "MCP server for Hostinger API",
   "repository": {
     "url": "https://github.com/hostinger/api-mcp-server",
     "source": "github"
   },
-  "version": "0.1.19",
+  "version": "0.1.20",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "hostinger-api-mcp",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "transport": {
         "type": "stdio"
       },

--- a/server.ts
+++ b/server.ts
@@ -3444,7 +3444,7 @@ class MCPServer {
     this.server = new Server(
       {
         name: "hostinger-api-mcp",
-        version: "0.1.19",
+        version: "0.1.20",
       },
       {
         capabilities: {
@@ -3469,7 +3469,7 @@ class MCPServer {
       });
     }
     
-    headers['User-Agent'] = 'hostinger-mcp-server/0.1.19';
+    headers['User-Agent'] = 'hostinger-mcp-server/0.1.20';
     
     return headers;
   }


### PR DESCRIPTION
## Related Issue
 https://hostingers.atlassian.net/browse/VPS-4617



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.20
  * Server identifier updated to reflect new naming scheme
  * Configuration and metadata updated across project files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->