### PR TITLE
Handle version flag before server startup

### DIFF
--- a/src/core/runtime.js
+++ b/src/core/runtime.js
@@ -2066,9 +2066,15 @@ class MCPServer {
 export async function startServer({ name, version, tools }) {
   const argv = minimist(process.argv.slice(2), {
     string: ['host'],
-    boolean: ['stdio', 'http', 'help', 'login', 'logout'],
+    boolean: ['stdio', 'http', 'help', 'version', 'login', 'logout'],
+    alias: { h: 'help', v: 'version' },
     default: { host: '127.0.0.1', port: 8100, stdio: true }
   });
+
+  if (argv.version) {
+    console.log(version);
+    process.exit(0);
+  }
 
   if (argv.help) {
     console.log(`
@@ -2081,6 +2087,7 @@ export async function startServer({ name, version, tools }) {
         --port <port>        Port to bind to (default: 8100)
         --login              Run OAuth sign-in flow and exit
         --logout             Revoke stored OAuth credentials and exit
+        --version, -v        Show version number
         --help               Show this help message
       Environment Variables:
         HOSTINGER_API_TOKEN  Hostinger API token (overrides OAuth when set)

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -2104,9 +2104,15 @@ class MCPServer {
 export async function startServer({ name, version, tools }: { name: string; version: string; tools: OpenApiTool[] }): Promise<void> {
   const argv = minimist(process.argv.slice(2), {
     string: ['host'],
-    boolean: ['stdio', 'http', 'help', 'login', 'logout'],
+    boolean: ['stdio', 'http', 'help', 'version', 'login', 'logout'],
+    alias: { h: 'help', v: 'version' },
     default: { host: '127.0.0.1', port: 8100, stdio: true }
   });
+  if (argv.version) {
+    console.log(version);
+    process.exit(0);
+  }
+
   if (argv.help) {
     console.log(`
       ${name}
@@ -2118,6 +2124,7 @@ export async function startServer({ name, version, tools }: { name: string; vers
         --port <port>        Port to bind to (default: 8100)
         --login              Run OAuth sign-in flow and exit
         --logout             Revoke stored OAuth credentials and exit
+        --version, -v        Show version number
         --help               Show this help message
       Environment Variables:
         HOSTINGER_API_TOKEN  Hostinger API token (overrides OAuth when set)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` and `-v` command-line flags to display the server version and exit immediately.
  * Updated help documentation to include the new version flag option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->