### PR TITLE
Tag release from package.json version instead of tag-action

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -13,27 +13,37 @@ jobs:
       id-token: write
       contents: write
     outputs:
-      new_version: ${{ steps.bump.outputs.new_version }}
+      new_version: ${{ steps.version.outputs.version }}
+      released: ${{ steps.version.outputs.released }}
     steps:
       - name: Repo checkout
         uses: actions/checkout@v4
-
-      - name: Bump version and push tag
-        id: bump
-        uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: main
+          fetch-depth: 0
 
-      - name: Release tag
+      - name: Resolve version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "Tag v$VERSION already exists — skipping release."
+          else
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        if: steps.version.outputs.released == 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.bump.outputs.new_tag }}
+          tag: v${{ steps.version.outputs.version }}
           generateReleaseNotes: true
 
   publish-npmjs:
     runs-on: ubuntu-latest
     needs: [release]
+    if: needs.release.outputs.released == 'true'
     permissions:
       contents: read
       id-token: write
@@ -57,6 +67,7 @@ jobs:
   release-github:
     runs-on: ubuntu-latest
     needs: [release]
+    if: needs.release.outputs.released == 'true'
     permissions:
       contents: read
       id-token: write
@@ -83,6 +94,7 @@ jobs:
   publish-mcp:
     runs-on: ubuntu-latest
     needs: [ release, publish-npmjs ]
+    if: needs.release.outputs.released == 'true'
     permissions:
       id-token: write
       contents: read
@@ -99,12 +111,6 @@ jobs:
         run: |
           curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
           chmod +x ./mcp-publisher
-
-      - name: Sync version in server.json
-        run: |
-          VERSION=${{ needs.release.outputs.new_version }}
-          jq --arg v "$VERSION" '.version = $v | .packages[0].version = $v' server.json > tmp && mv tmp server.json
-          cat server.json
 
       - name: Login to MCP Registry using GitHub OIDC
         run: ./mcp-publisher login github-oidc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to detect previously published versions and prevent duplicate releases.
  * Refined publication gating to ensure controlled, conditional publishing across package registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->