### PR TITLE
Add Gemini CLI extension manifest

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,22 @@
+{
+  "name": "hostinger-api-mcp",
+  "version": "0.2.19",
+  "description": "Manage your Hostinger account from Gemini CLI — domains, DNS, hosting, VPS, billing, e-commerce and more via the Hostinger API.",
+  "mcpServers": {
+    "hostinger": {
+      "command": "npx",
+      "args": ["-y", "hostinger-api-mcp"],
+      "env": {
+        "HOSTINGER_API_TOKEN": "${HOSTINGER_API_TOKEN}"
+      }
+    }
+  },
+  "settings": [
+    {
+      "name": "Hostinger API Token",
+      "description": "Hostinger API token from hpanel.hostinger.com/profile/api. Optional — if left unset, the server falls back to interactive OAuth sign-in in stdio mode.",
+      "envVar": "HOSTINGER_API_TOKEN",
+      "sensitive": true
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a \`gemini-extension.json\` manifest at the repo root so the Hostinger MCP server can be used as a [Gemini CLI extension](https://geminicli.com/docs/extensions/).

## Why

With this file present, users can install the connector directly:

\`\`\`bash
gemini extensions install https://github.com/hostinger/api-mcp-server
\`\`\`

It also makes the connector eligible for the [Gemini CLI extensions gallery](https://geminicli.com/extensions/browse/), which auto-discovers public repos.

## Manifest details

- Runs the published npm package via \`npx -y hostinger-api-mcp\` (no local build required by users).
- Declares \`HOSTINGER_API_TOKEN\` as a **sensitive** setting so Gemini prompts for it securely; OAuth interactive sign-in remains the fallback when it is unset.
- \`version\` set to \`0.2.19\` to match the current package version.

## Remaining steps for maintainers (require write/admin)

To complete the gallery listing after merge:

1. Add the GitHub topic \`gemini-cli-extension\` to the repo's About section (the crawler uses this to discover the extension).
2. On the next release, keep the \`version\` in \`gemini-extension.json\`, \`package.json\`, and the git tag in lockstep so update detection works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Hostinger MCP integration.
  * You can now provide a Hostinger API token for direct authentication, or leave it unset to sign in interactively when prompted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->