### PR TITLE
Add a CHANGELOG covering the last ten releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+Generated at release time from the diff between the previous and current
+build. Tool changes are listed individually; everything else is summarised
+by area.
+
+## v1.53.0 — 2026-09-02
+
+### Also in this release
+
+- Dependencies: `package-lock.json`
+- Distribution manifests: `server.json`
+
+## v1.52.2 — 2026-09-01
+
+No changes to the published artifact.
+
+## v1.52.1 — 2026-09-01
+
+### Also in this release
+
+- Dependencies: `package-lock.json`
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+
+## v1.52.0 — 2026-08-28
+
+### Also in this release
+
+- Release automation: `.github/workflows/build-release.yaml`
+- Documentation: `README.md`
+- Distribution manifests: `gemini-extension.json`, `server.json`
+- Dependencies: `package-lock.json`, `package.json`
+- Bundled agent skills: `skills/headless/entry/bootstrap.mjs`
+
+## v1.51.1 — 2026-08-27
+
+### Tools
+
+- Changed the description and input schema of `VPS_replaceAllFirewallRulesInGroupV1`
+
+### Also in this release
+
+- Documentation: `README.md`
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+- Build and packaging: `types.d.ts`
+
+## v1.51.0 — 2026-08-27
+
+### Tools
+
+- Updated the title and annotations of 372 tools (all)
+
+### Also in this release
+
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+
+## v1.50.0 — 2026-08-27
+
+### Tools
+
+- Added `VPS_replaceAllFirewallRulesInGroupV1`
+
+### Also in this release
+
+- Documentation: `README.md`
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+- Build and packaging: `types.d.ts`
+
+## v1.49.0 — 2026-08-27
+
+### Also in this release
+
+- Dependencies: `package-lock.json`
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+
+## v1.48.0 — 2026-08-26
+
+### Tools
+
+- Added `hosting_listNode_jsEnvironmentVariablesV1`
+- Added `hosting_replaceNode_jsEnvironmentVariablesV1`
+
+### Also in this release
+
+- Documentation: `README.md`
+- Dependencies: `package-lock.json`
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+- Build and packaging: `types.d.ts`
+
+## v1.47.0 — 2026-08-25
+
+### Also in this release
+
+- Release automation: `.github/workflows/build-release.yaml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Generated at release time from the diff between the previous and current
 build. Tool changes are listed individually; everything else is summarised
 by area.
 
+## v1.54.0 — 2026-09-03
+
+### Tools
+
+- Changed the input schema of `agency-hosting_createANewWebsiteV1`
+
+### Also in this release
+
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+- Build and packaging: `types.d.ts`
+
 ## v1.53.1 — 2026-09-03
 
 ### Tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Generated at release time from the diff between the previous and current
 build. Tool changes are listed individually; everything else is summarised
 by area.
 
+## v1.53.1 — 2026-09-03
+
+### Tools
+
+- Added `reach_createADraftCampaignV1` — Create a draft campaign
+- Added `reach_listEmailTemplatesV1` — List email templates
+- Added `reach_createAnEmailTemplateV1` — Create an email template
+
+### Also in this release
+
+- Documentation: `README.md`
+- Dependencies: `package-lock.json`
+- Request handling and authentication: `src/core/runtime.js`, `src/core/runtime.ts`
+- Build and packaging: `types.d.ts`
+
 ## v1.53.0 — 2026-09-02
 
 ### Also in this release


### PR DESCRIPTION
Seeds `CHANGELOG.md` with the last ten releases, so the file has real history before the generator starts appending to it.

Every release body in this repo is currently the same 89-character auto-generated compare link. With ~99 releases since July, nothing records what changed — including genuine capability news. `v1.48.0` added two Node.js environment-variable tools and `v1.50.0` added a VPS firewall tool; none of that is visible anywhere today.

## How the entries were derived

From the diff between consecutive tags, using the generated tool list each tag carries. Tool changes are listed individually, everything else is summarised by area, and version-string churn is filtered out — otherwise every release would report the same three areas, since the version is rewritten into `package.json`, the lock file and all twelve server entry points on each release.

Dates come from the tags, not from when this was generated.

## Depends on hostinger/public-api-generator#140

⚠️ **Please merge [public-api-generator#141](https://github.com/hostinger/public-api-generator/pull/141) before this.**

This repository is a generated mirror. The push workflow copies the downstream `.git` over a freshly generated tree and runs `git add .`, which stages deletions for anything present in `HEAD` but absent from the generated output. Until #141 teaches the generator to write `CHANGELOG.md`, the next regeneration would delete this file.

Once #141 is in, the generator reads the accumulated entries from `HEAD` and prepends each new release, so this history persists and grows.

## Note on the honest entries

One section reads:

```
## v1.52.2 — 2026-09-01

No changes to the published artifact.
```

That is accurate — `v1.52.2` changed 28 files, all of them version-string churn. It is worth keeping rather than hiding, since it tells a reader not to bother upgrading for that one.
